### PR TITLE
Added support for DbQuery mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 [![Build Status](https://travis-ci.org/MichalJankowskii/Moq.EntityFrameworkCore.svg?branch=master)](https://travis-ci.org/MichalJankowskii/Moq.EntityFrameworkCore)
 [![Downloads](https://img.shields.io/nuget/dt/Moq.EntityFrameworkCore.svg)](https://www.nuget.org/packages/Moq.EntityFrameworkCore/)
 
-This library helps you with mocking EntityFramework contexts. Now you will be able to test methods that are using `DbSet<TEntity>` or `DbQuery<TEntity>` from `DbContext` in an effective way.
+This library helps you mocking EntityFramework contexts. Now you will be able to test methods that are using `DbSet<TEntity>` or `DbQuery<TEntity>` from `DbContext` in an effective way.
 ## Installation - NuGet Packages
 ```
 Install-Package Moq.EntityFrameworkCore
 ```
 
 ## Usage
-For example we can assume that we have following production code:
+For example we can assume that we have the following production code:
 ```
 public class UsersContext : DbContext
 {
@@ -19,7 +19,7 @@ public class UsersContext : DbContext
 }
 ```
 
-For mocking Users you need only to implement following 3 steps:
+To mock Users and Roles you only need to implement the following 3 steps:
 
 1\. Create `DbContext` mock:
 ```csharp
@@ -38,4 +38,4 @@ userContextMock.Setup(x => x.Roles).ReturnsDbQuery(roles);
 
 And this is all. You can use your `DbContext` in your tests.
 
-You will find examples of this library in [repository](https://github.com/MichalJankowskii/Moq.EntityFrameworkCore/blob/master/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs).
+You will find examples of this library in the [repository](https://github.com/MichalJankowskii/Moq.EntityFrameworkCore/blob/master/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/MichalJankowskii/Moq.EntityFrameworkCore.svg?branch=master)](https://travis-ci.org/MichalJankowskii/Moq.EntityFrameworkCore)
 [![Downloads](https://img.shields.io/nuget/dt/Moq.EntityFrameworkCore.svg)](https://www.nuget.org/packages/Moq.EntityFrameworkCore/)
 
-This library helps you with mocking EntityFramework contexts. Now you will be able to test methods that are using `DbSet<TEntity>` from `DbContext` in effective way.
+This library helps you with mocking EntityFramework contexts. Now you will be able to test methods that are using `DbSet<TEntity>` or `DbQuery<TEntity>` from `DbContext` in an effective way.
 ## Installation - NuGet Packages
 ```
 Install-Package Moq.EntityFrameworkCore
@@ -14,10 +14,12 @@ For example we can assume that we have following production code:
 public class UsersContext : DbContext
 {
     public virtual DbSet<User> Users { get; set; }
+
+    public virtual DbQuery<Role> Roles { get; set; }
 }
 ```
 
-For mocking Users you need only implement following 3 steps:
+For mocking Users you need only to implement following 3 steps:
 
 1\. Create `DbContext` mock:
 ```csharp
@@ -26,10 +28,12 @@ var userContextMock = new Mock<UsersContext>();
 2\. Generate your entities:
 ```csharp
 IList<User> users = ...;
+IList<Roles> roles = ...;
 ```
-3\. Setup `DbSet` propery:
+3\. Setup `DbSet` or `DbQuery` property:
 ```csharp
 userContextMock.Setup(x => x.Users).ReturnsDbSet(users);
+userContextMock.Setup(x => x.Roles).ReturnsDbQuery(roles);
 ```
 
 And this is all. You can use your `DbContext` in your tests.

--- a/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
+++ b/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
@@ -5,12 +5,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
-    <PackageReference Include="Moq" Version="4.8.0" />
-    <PackageReference Include="Moq.EntityFrameworkCore" Version="2.0.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="AutoFixture" Version="4.8.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.1" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Moq.EntityFrameworkCore\Moq.EntityFrameworkCore.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Moq.EntityFrameworkCore.Examples/Users/UsersContext.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/Users/UsersContext.cs
@@ -6,6 +6,7 @@
     public class UsersContext : DbContext
     {
         public virtual DbSet<User> Users { get; set; }
-        public virtual DbSet<Role> Roles { get; set; }
+
+        public virtual DbQuery<Role> Roles { get; set; }
     }
 }

--- a/src/Moq.EntityFrameworkCore.Examples/Users/UsersService.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/Users/UsersService.cs
@@ -24,5 +24,15 @@
         {
             return await this.usersContext.Users.Where(x => x.AccountLocked).ToListAsync();
         }
+
+        public IList<Role> GetDisabledRoles()
+        {
+            return this.usersContext.Roles.Where(x => !x.IsEnabled).ToList();
+        }
+
+        public async Task<IList<Role>> GetDisabledRolesAsync()
+        {
+            return await this.usersContext.Roles.Where(x => !x.IsEnabled).ToListAsync();
+        }
     }
 }

--- a/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs
@@ -1,11 +1,11 @@
 ﻿namespace Moq.EntityFrameworkCore.Examples
 {
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
     using AutoFixture;
     using Moq.EntityFrameworkCore;
     using Moq.EntityFrameworkCore.Examples.Users;
     using Moq.EntityFrameworkCore.Examples.Users.Entities;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Xunit;
 
     public class UsersServiceTest
@@ -29,7 +29,7 @@
             var lockedUsers = usersService.GetLockedUsers();
 
             // Assert
-            Assert.Equal(new List<User> {lockedUser}, lockedUsers);
+            Assert.Equal(new List<User> { lockedUser }, lockedUsers);
         }
 
         [Fact]
@@ -52,12 +52,63 @@
             Assert.Equal(new List<User> { lockedUser }, lockedUsers);
         }
 
+        [Fact]
+        public void Given_ListOfGroupsWithOneGroupDisabled_When_CheckingWhichOneIsDisabled_Then_CorrectDisabledRoleIsReturned()
+        {
+            // Arrange
+            IList<Role> roles = GenerateEnabledGroups();
+            var disabledRole = Fixture.Build<Role>().With(u => u.IsEnabled, false).Create();
+            roles.Add(disabledRole);
+
+            var userContextMock = new Mock<UsersContext>();
+            userContextMock.Setup(x => x.Roles).ReturnsDbQuery(roles);
+
+            var usersService = new UsersService(userContextMock.Object);
+
+            // Act
+            var disabledRoles = usersService.GetDisabledRoles();
+
+            // Assert
+            Assert.Equal(new List<Role> { disabledRole }, disabledRoles);
+        }
+
+        [Fact]
+        public async Task Given_ListOfGroupsWithOneGroupDisabled_When_CheckingWhichOneIsDisabledAsync_Then_CorrectDisabledRoleIsReturned()
+        {
+            // Arrange
+            IList<Role> roles = GenerateEnabledGroups();
+            var disabledRole = Fixture.Build<Role>().With(u => u.IsEnabled, false).Create();
+            roles.Add(disabledRole);
+
+            var userContextMock = new Mock<UsersContext>();
+            userContextMock.Setup(x => x.Roles).ReturnsDbQuery(roles);
+
+            var usersService = new UsersService(userContextMock.Object);
+
+            // Act
+            var disabledRoles = await usersService.GetDisabledRolesAsync();
+
+            // Assert
+            Assert.Equal(new List<Role> { disabledRole }, disabledRoles);
+        }
+
         private static IList<User> GenerateNotLockedUsers()
         {
             IList<User> users = new List<User>
             {
                 Fixture.Build<User>().With(u => u.AccountLocked, false).Create(),
                 Fixture.Build<User>().With(u => u.AccountLocked, false).Create()
+            };
+
+            return users;
+        }
+
+        private static IList<Role> GenerateEnabledGroups()
+        {
+            IList<Role> users = new List<Role>
+            {
+                Fixture.Build<Role>().With(u => u.IsEnabled, true).Create(),
+                Fixture.Build<Role>().With(u => u.IsEnabled, true).Create()
             };
 
             return users;

--- a/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
+++ b/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
@@ -5,11 +5,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
-    <PackageReference Include="Moq" Version="4.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.1" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Moq.EntityFrameworkCore/Moq.EntityFrameworkCore.csproj
+++ b/src/Moq.EntityFrameworkCore/Moq.EntityFrameworkCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
-    <PackageReference Include="Moq" Version="4.8.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.1" />
+    <PackageReference Include="Moq" Version="4.10.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Moq.EntityFrameworkCore/MoqExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/MoqExtensions.cs
@@ -10,8 +10,28 @@
     {
         public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities) where T : DbContext where TEntity : class
         {
-            var entitiesAsQueryable = entities.AsQueryable();
             var dbSetMock = new Mock<DbSet<TEntity>>();
+
+            ConfigureMock(dbSetMock, entities);
+
+            return setupResult.Returns(dbSetMock.Object);
+        }
+
+        public static IReturnsResult<T> ReturnsDbQuery<T, TEntity>(this ISetup<T, DbQuery<TEntity>> setupResult, IEnumerable<TEntity> entities) where T : DbContext where TEntity : class
+        {
+            var dbQueryMock = new Mock<DbQuery<TEntity>>();
+
+            ConfigureMock(dbQueryMock, entities);
+
+            return setupResult.Returns(dbQueryMock.Object);
+        }
+
+        /// <summary>
+        /// Configures a Mock for a <see cref="DbSet{TEntity}"/> or a <see cref="DbQuery{TQuery}"/> so that it can be queriable via LINQ
+        /// </summary>
+        private static void ConfigureMock<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities) where TEntity : class
+        {
+            var entitiesAsQueryable = entities.AsQueryable();
 
             dbSetMock.As<IAsyncEnumerable<TEntity>>()
                .Setup(m => m.GetEnumerator())
@@ -24,8 +44,6 @@
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(entitiesAsQueryable.Expression);
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(entitiesAsQueryable.ElementType);
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(entitiesAsQueryable.GetEnumerator());
-
-            return setupResult.Returns(dbSetMock.Object);
         }
     }
 }


### PR DESCRIPTION
Entity Framework Core 2.1 has introduced the concept of [Query Types](https://docs.microsoft.com/en-us/ef/core/modeling/query-types) that use the class `DbQuery` and are used, among other things, to map Database Views.  

The mocking code required to support `DbQuery` is literally the same as `DbSet`, this pull request implements the support to mock `DbQuery` by extending the class `MoqExtensions` with a new method called `ReturnsDbQuery`.  

To implement `ReturnsDbQuery` I've generalized the setup code (has I said is identical) used to implement `ReturnsDbSet` in a method called `ConfigureMock` that is called by both `ReturnsDbQuery` and `ReturnsDbSet`.  
To test the new method I had to remove the NuGet reference to `Moq.EntityFrameworkCore` from Moq.EntityFrameworkCore.Examples in favor of referencing directly the project `Moq.EntityFrameworkCore`.  

I've also updated Moq and Entity Framework Core to their latest version, if this Pull Request is accepted I would advise to release a new major version.

I've took the liberty to fix some small English mistakes in the README file.
