### PR TITLE
Fix Issue#11

### DIFF
--- a/src/Moq.EntityFrameworkCore.Examples/Users/UsersService.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/Users/UsersService.cs
@@ -1,10 +1,12 @@
 ﻿namespace Moq.EntityFrameworkCore.Examples.Users
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
     using Moq.EntityFrameworkCore.Examples.Users.Entities;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Threading.Tasks;
 
     public class UsersService
     {
@@ -33,6 +35,11 @@
         public async Task<IList<Role>> GetDisabledRolesAsync()
         {
             return await this.usersContext.Roles.Where(x => !x.IsEnabled).ToListAsync();
+        }
+
+        public async Task<User> FindOneUserAsync(Expression<Func<User, bool>> predicate)
+        {
+            return await this.usersContext.Set<User>().FirstOrDefaultAsync(predicate);
         }
     }
 }

--- a/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs
@@ -7,6 +7,7 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Xunit;
+    using System.Linq;
 
     public class UsersServiceTest
     {
@@ -90,6 +91,23 @@
 
             // Assert
             Assert.Equal(new List<Role> { disabledRole }, disabledRoles);
+        }
+
+        [Fact]
+        public async Task Given_ListOfUser_When_FindOneUserAsync_Then_CorrectUserIsReturned()
+        {
+            var users = GenerateNotLockedUsers();
+            var userContextMock = new Mock<UsersContext>();
+            userContextMock.Setup(x => x.Set<User>()).ReturnsDbSet(users);
+
+            var usersService = new UsersService(userContextMock.Object);
+            var user = users.FirstOrDefault();
+
+            //Act
+            var userToAssert = await usersService.FindOneUserAsync(x => x.Id == user.Id);
+
+            //Assert
+            Assert.Equal(userToAssert, user);
         }
 
         private static IList<User> GenerateNotLockedUsers()

--- a/src/Moq.EntityFrameworkCore.Tests/DbAsyncQueryProvider/InMemoryAsyncQueryProviderTests.cs
+++ b/src/Moq.EntityFrameworkCore.Tests/DbAsyncQueryProvider/InMemoryAsyncQueryProviderTests.cs
@@ -66,7 +66,7 @@
             this.inMemoryAsyncQueryProvider.ExecuteAsync<int>(this.expression);
 
             // Assert
-            this.queryProviderMock.Verify(x => x.Execute<int>(this.expression));
+            this.queryProviderMock.Verify(x => x.Execute(this.expression));
         }
 
         [Fact]
@@ -86,7 +86,7 @@
             this.inMemoryAsyncQueryProvider.ExecuteAsync<int>(this.expression, CancellationToken.None);
 
             // Assert
-            this.queryProviderMock.Verify(x => x.Execute<int>(this.expression));
+            this.queryProviderMock.Verify(x => x.Execute(this.expression));
         }
     }
 }

--- a/src/Moq.EntityFrameworkCore/DbAsyncQueryProvider/InMemoryAsyncQueryProvider.cs
+++ b/src/Moq.EntityFrameworkCore/DbAsyncQueryProvider/InMemoryAsyncQueryProvider.cs
@@ -37,9 +37,20 @@
 
         public TResult ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken = new CancellationToken())
         {
-            return Execute<TResult>(expression);
+            var result = Execute(expression);
+            
+            var expectedResultType = typeof(TResult).GetGenericArguments()?.FirstOrDefault();
+            if (expectedResultType == null)
+            {
+                return default(TResult);
+            }
+
+            return (TResult)typeof(Task).GetMethod(nameof(Task.FromResult))
+                ?.MakeGenericMethod(expectedResultType)
+                .Invoke(null, new[] { result });
         }
-        
+
+
         public Task<object> ExecuteAsync(Expression expression, CancellationToken cancellationToken)
         {
             return Task.FromResult(this.Execute(expression));


### PR DESCRIPTION
This pull-request aims to fix the issue #11 

The problem comes from the change from `IAsyncQueryProvider`. Someone in EF Core team said that they have no intention of supporting fake async calls (please see this [issue](https://github.com/aspnet/EntityFrameworkCore/issues/16864))

They also suggested the solution which use reflection - please see [their comment](https://github.com/aspnet/EntityFrameworkCore/issues/16864#issuecomment-516852769)

In this pull-request, I've added another method into `UsersService` which using `DbSet` and `FirstOrDefaultAsync`. The unit test is also added.

Hope it's useful. Thanks.
