### PR TITLE
Updated packages and added extension method for SetupSequence support.

### DIFF
--- a/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
+++ b/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
+++ b/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
@@ -6,10 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Moq.EntityFrameworkCore.Examples/Users/UsersService.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/Users/UsersService.cs
@@ -41,5 +41,20 @@
         {
             return await this.usersContext.Set<User>().FirstOrDefaultAsync(predicate);
         }
+
+        public async Task<IList<User>> ChangeSetInSequence()
+        {
+            var users = await this.usersContext.Users.ToListAsync();
+
+            if (users.Count == 0)
+            {
+                // This simulates a method that changes the contents of the list between calls
+                // as frequenty happens when side effects from other services change a DbSet
+
+                return await this.usersContext.Users.ToListAsync();
+            }
+
+            return new List<User>();
+        }
     }
 }

--- a/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs
@@ -110,6 +110,26 @@
             Assert.Equal(userToAssert, user);
         }
 
+        [Fact]
+        public async Task Given_Two_ListOfUser_Then_CorrectListIsReturned_InSequence()
+        {
+            var users = GenerateNotLockedUsers();
+            var userContextMock = new Mock<UsersContext>();
+            userContextMock.SetupSequence(x => x.Users)
+                .ReturnsDbSet(new List<User>())
+                .ReturnsDbSet(users);
+
+            var usersService = new UsersService(userContextMock.Object);
+
+            // Act
+            var userResults = await usersService.ChangeSetInSequence();
+
+            //Assert
+            Assert.Equal(users.Count, userResults.Count);
+            Assert.Equal(userResults[0].Login, users[0].Login);
+            Assert.Equal(userResults[1].Login, users[1].Login);
+        }
+
         private static IList<User> GenerateNotLockedUsers()
         {
             IList<User> users = new List<User>

--- a/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
+++ b/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
@@ -5,14 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
+++ b/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Moq.EntityFrameworkCore/Moq.EntityFrameworkCore.csproj
+++ b/src/Moq.EntityFrameworkCore/Moq.EntityFrameworkCore.csproj
@@ -18,8 +18,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Moq" Version="4.14.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Moq.EntityFrameworkCore/MoqExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/MoqExtensions.cs
@@ -6,6 +6,8 @@
     using System.Threading;
     using Microsoft.EntityFrameworkCore;
     using Moq.EntityFrameworkCore.DbAsyncQueryProvider;
+
+    using Moq.Language;
     using Moq.Language.Flow;
 
     public static class MoqExtensions
@@ -27,6 +29,15 @@
             ConfigureMock(dbQueryMock, entities);
 
             return setupResult.Returns(dbQueryMock.Object);
+        }
+
+        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSet<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>> dbSetMock = null) where TEntity : class
+        {
+            dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
+
+            ConfigureMock(dbSetMock, entities);
+
+            return setupResult.Returns(dbSetMock.Object);
         }
 
         /// <summary>


### PR DESCRIPTION
Hey Michael, thanks for this great library. 

One problem I had with using it was Moq's SetupSequence (chaining results) didn't work with ReturnsDbSet.

In this PR, I updated dependent packages to their latest versions and added an extension method to support it (it was basically a copy of one of your other extension methods with a different method signature).

You can omit updating the nuget packages if you have any concerns, but would love to see this merged in when you have a chance! Let me know anything else you'd like me to do to accept this.