### PR TITLE
updated to EF5, moved failing namespace, bumped framework

### DIFF
--- a/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
+++ b/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/src/Moq.EntityFrameworkCore.Examples/Users/UsersContext.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/Users/UsersContext.cs
@@ -6,7 +6,5 @@
     public class UsersContext : DbContext
     {
         public virtual DbSet<User> Users { get; set; }
-
-        public virtual DbQuery<Role> Roles { get; set; }
-    }
+	}
 }

--- a/src/Moq.EntityFrameworkCore.Examples/Users/UsersService.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/Users/UsersService.cs
@@ -27,16 +27,6 @@
             return await this.usersContext.Users.Where(x => x.AccountLocked).ToListAsync();
         }
 
-        public IList<Role> GetDisabledRoles()
-        {
-            return this.usersContext.Roles.Where(x => !x.IsEnabled).ToList();
-        }
-
-        public async Task<IList<Role>> GetDisabledRolesAsync()
-        {
-            return await this.usersContext.Roles.Where(x => !x.IsEnabled).ToListAsync();
-        }
-
         public async Task<User> FindOneUserAsync(Expression<Func<User, bool>> predicate)
         {
             return await this.usersContext.Set<User>().FirstOrDefaultAsync(predicate);

--- a/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs
@@ -53,45 +53,6 @@
             Assert.Equal(new List<User> { lockedUser }, lockedUsers);
         }
 
-        [Fact]
-        public void Given_ListOfGroupsWithOneGroupDisabled_When_CheckingWhichOneIsDisabled_Then_CorrectDisabledRoleIsReturned()
-        {
-            // Arrange
-            IList<Role> roles = GenerateEnabledGroups();
-            var disabledRole = Fixture.Build<Role>().With(u => u.IsEnabled, false).Create();
-            roles.Add(disabledRole);
-
-            var userContextMock = new Mock<UsersContext>();
-            userContextMock.Setup(x => x.Roles).ReturnsDbQuery(roles);
-
-            var usersService = new UsersService(userContextMock.Object);
-
-            // Act
-            var disabledRoles = usersService.GetDisabledRoles();
-
-            // Assert
-            Assert.Equal(new List<Role> { disabledRole }, disabledRoles);
-        }
-
-        [Fact]
-        public async Task Given_ListOfGroupsWithOneGroupDisabled_When_CheckingWhichOneIsDisabledAsync_Then_CorrectDisabledRoleIsReturned()
-        {
-            // Arrange
-            IList<Role> roles = GenerateEnabledGroups();
-            var disabledRole = Fixture.Build<Role>().With(u => u.IsEnabled, false).Create();
-            roles.Add(disabledRole);
-
-            var userContextMock = new Mock<UsersContext>();
-            userContextMock.Setup(x => x.Roles).ReturnsDbQuery(roles);
-
-            var usersService = new UsersService(userContextMock.Object);
-
-            // Act
-            var disabledRoles = await usersService.GetDisabledRolesAsync();
-
-            // Assert
-            Assert.Equal(new List<Role> { disabledRole }, disabledRoles);
-        }
 
         [Fact]
         public async Task Given_ListOfUser_When_FindOneUserAsync_Then_CorrectUserIsReturned()

--- a/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
+++ b/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">

--- a/src/Moq.EntityFrameworkCore/DbAsyncQueryProvider/InMemoryAsyncQueryProvider.cs
+++ b/src/Moq.EntityFrameworkCore/DbAsyncQueryProvider/InMemoryAsyncQueryProvider.cs
@@ -4,9 +4,9 @@
     using System.Linq.Expressions;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.EntityFrameworkCore.Query.Internal;
+    using Microsoft.EntityFrameworkCore.Query;
 
-    public class InMemoryAsyncQueryProvider<TEntity> : IAsyncQueryProvider
+	public class InMemoryAsyncQueryProvider<TEntity> : IAsyncQueryProvider
     {
         private readonly IQueryProvider innerQueryProvider;
 

--- a/src/Moq.EntityFrameworkCore/Moq.EntityFrameworkCore.csproj
+++ b/src/Moq.EntityFrameworkCore/Moq.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyVersion>2.0.2.0</AssemblyVersion>
     <FileVersion>2.0.2.0</FileVersion>
     <Version>3.1.2</Version>
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
   </ItemGroup>
 

--- a/src/Moq.EntityFrameworkCore/MoqExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/MoqExtensions.cs
@@ -19,15 +19,6 @@
             return setupResult.Returns(dbSetMock.Object);
         }
 
-        [Obsolete("Use ReturnsDbSet<T, TEntity> instead")]
-        public static IReturnsResult<T> ReturnsDbQuery<T, TEntity>(this ISetup<T, DbQuery<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbQuery<TEntity>> dbQueryMock = null) where T : class where TEntity : class
-        {
-            dbQueryMock = dbQueryMock ?? new Mock<DbQuery<TEntity>>();
-
-            ConfigureMock(dbQueryMock, entities);
-
-            return setupResult.Returns(dbQueryMock.Object);
-        }
 
         /// <summary>
         /// Configures a Mock for a <see cref="DbSet{TEntity}"/> or a <see cref="DbQuery{TQuery}"/> so that it can be queriable via LINQ


### PR DESCRIPTION
Hi Michael.

Your project is great, but i wanted to use it with EFCore 5. The issue is that they moved a namespace and deleted the obsolete DBQuery. I've Moved them and updated EF in this pull