### PR TITLE
.NET 6 support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ steps:
   displayName: 'Use .NET Core sdk'
   inputs:
     packageType: sdk
-    version: 6.0.1
+    version: 6.0.101
     installationPath: $(Agent.ToolsDirectory)/dotnet
 - task: DotNetCoreCLI@2
   displayName: 'Building'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,12 @@ variables:
 steps:
 - bash: echo $(packageVersion)
   displayName: Print version
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk'
+  inputs:
+    packageType: sdk
+    version: 6.0.1
+    installationPath: $(Agent.ToolsDirectory)/dotnet
 - task: DotNetCoreCLI@2
   displayName: 'Building'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,8 @@ pool:
 
 variables:
   buildConfiguration: 'Release'
-  efVersion: '5.0.0'
-  versionBuildNumber: $[counter('5.0.0', 1)]
+  efVersion: '6.0.1'
+  versionBuildNumber: $[counter('6.0.0', 1)]
   packageVersion: $(efVersion).$(versionBuildNumber)
 
 steps:

--- a/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
+++ b/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
@@ -9,7 +9,7 @@
 	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
+++ b/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
+++ b/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
@@ -6,13 +6,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
+++ b/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">

--- a/src/Moq.EntityFrameworkCore/Moq.EntityFrameworkCore.csproj
+++ b/src/Moq.EntityFrameworkCore/Moq.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <FileVersion>5.0.2.0</FileVersion>
     <Version>3.1.2</Version>
@@ -13,12 +13,12 @@
     <PackageProjectUrl>https://github.com/MichalJankowskii/Moq.EntityFrameworkCore</PackageProjectUrl>
     <RepositoryUrl>https://github.com/MichalJankowskii/Moq.EntityFrameworkCore</RepositoryUrl>
     <PackageTags>Moq mocking EF EnityFramework DbSet DbContext unit test testing framework assert TDD BDD EntityFrameworkCore EFCore Core</PackageTags>
-    <PackageReleaseNotes>- Migration to EFCore 5.0</PackageReleaseNotes>
+    <PackageReleaseNotes>- Migration to EFCore 6.0.1</PackageReleaseNotes>
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Considering the fact that .NET 6 is ready for production, I think it would be great if this package supports it. 

Otherwise, the apps that have installed Microsoft.EntityFrameworkCore >= 6.0.0 will not be able to run Moq.EntityFrameworkCore.

Also, I needed to add Microsoft.NET.Test.Sdk to Moq.EntityFrameworkCore.Tests project in order to run the tests.