### PR TITLE
📦 Downgrade Moq to it's not invasive version

### DIFF
--- a/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
+++ b/src/Moq.EntityFrameworkCore.Examples/Moq.EntityFrameworkCore.Examples.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
+++ b/src/Moq.EntityFrameworkCore.Tests/Moq.EntityFrameworkCore.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.console" Version="2.6.6">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Moq.EntityFrameworkCore/Moq.EntityFrameworkCore.csproj
+++ b/src/Moq.EntityFrameworkCore/Moq.EntityFrameworkCore.csproj
@@ -29,7 +29,7 @@ Added support for EntityFrameworkCore 8.0</PackageReleaseNotes>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
👋🏻 G'day!

So Moq screwed the pooch and added some invasive code in v 4.20+ called "Sponsorlink".

There's heaps of discussion on it on the interwebs .. but here's some links:

- https://ayende.com/blog/199905-C/on-moq-sponsorlink-some-thoughts
- https://www.youtube.com/watch?v=A06nNjBKV7I
- https://www.google.com.au/search?q=moq+sponsorlink

and the repo:
- https://github.com/devlooped/SponsorLink

So this PR is reverting back to the last version before all of this sponsorlink crapfest.