### PR TITLE
capture initial collection in lambda to always get new enumarator, me as IQueryable setup

### DIFF
--- a/src/Moq.EntityFrameworkCore/MoqExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/MoqExtensions.cs
@@ -47,7 +47,7 @@
 
             dbSetMock.As<IAsyncEnumerable<TEntity>>()
                .Setup(m => m.GetAsyncEnumerator(CancellationToken.None))
-               .Returns(new InMemoryDbAsyncEnumerator<TEntity>(entitiesAsQueryable.GetEnumerator()));
+               .Returns(() => new InMemoryDbAsyncEnumerator<TEntity>(entitiesAsQueryable.GetEnumerator()));
 
             dbSetMock.As<IQueryable<TEntity>>()
                 .Setup(m => m.Provider)


### PR DESCRIPTION
fixes #44 