### PR TITLE
fix: Make it easier for "users" to write their own extensions

### DIFF
--- a/src/Moq.EntityFrameworkCore/MoqExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/MoqExtensions.cs
@@ -41,7 +41,7 @@
         /// <summary>
         /// Configures a Mock for a <see cref="DbSet{TEntity}"/> or a <see cref="DbQuery{TQuery}"/> so that it can be queriable via LINQ
         /// </summary>
-        private static void ConfigureMock<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities) where TEntity : class
+        public static void ConfigureMock<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities) where TEntity : class
         {
             var entitiesAsQueryable = entities.AsQueryable();
 


### PR DESCRIPTION
Make ConfigureMock public - which is very useful to write you're own helper extension methods

Fixes #36 