### PR TITLE
Allow to mock FindAsync method

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet test:*)",
+      "Bash(dotnet build:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,1 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(dotnet test:*)",
-      "Bash(dotnet build:*)"
-    ]
-  }
-}
+{}

--- a/src/Moq.EntityFrameworkCore.Examples/Users/UsersService.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/Users/UsersService.cs
@@ -49,6 +49,11 @@
             return await this.usersContext.Set<User>().FirstOrDefaultAsync(predicate);
         }
 
+        public async Task<User> FindOneUserAsync(int id, CancellationToken cancellationToken)
+        {
+            return await this.usersContext.Set<User>().FindAsync(keyValues: [id], cancellationToken: cancellationToken);
+        }
+
         public async Task<IList<User>> GetAllUsersAsync(CancellationToken cancellationToken)
         {
             return await this.usersContext.Users.ToListAsync(cancellationToken);

--- a/src/Moq.EntityFrameworkCore.Examples/Users/UsersService.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/Users/UsersService.cs
@@ -1,4 +1,5 @@
-﻿namespace Moq.EntityFrameworkCore.Examples.Users
+﻿#nullable enable
+namespace Moq.EntityFrameworkCore.Examples.Users
 {
     using Microsoft.EntityFrameworkCore;
     using Moq.EntityFrameworkCore.Examples.Users.Entities;
@@ -44,12 +45,12 @@
             return await this.usersContext.Roles.Where(x => !x.IsEnabled).ToListAsync();
         }
 
-        public async Task<User> FindOneUserAsync(Expression<Func<User, bool>> predicate)
+        public async Task<User?> FindOneUserAsync(Expression<Func<User, bool>> predicate)
         {
             return await this.usersContext.Set<User>().FirstOrDefaultAsync(predicate);
         }
 
-        public async Task<User> FindOneUserAsync(int id, CancellationToken cancellationToken)
+        public async Task<User?> FindOneUserAsync(int id, CancellationToken cancellationToken)
         {
             return await this.usersContext.Set<User>().FindAsync(keyValues: [id], cancellationToken: cancellationToken);
         }

--- a/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs
@@ -235,7 +235,7 @@
             var usersContextMock = new Mock<UsersContext>();
             usersContextMock
                 .Setup(x => x.Set<User>())
-                .ReturnsDbSet(users, findByKeyExpression: u => u.Id); //findByKeyExpression is necessary to mock FindAsync
+                .ReturnsDbSet(users, findByKeyExpression: u => [u.Id]); //findByKeyExpression is necessary to mock FindAsync
 
             var usersService = new UsersService(usersContextMock.Object);
 

--- a/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs
+++ b/src/Moq.EntityFrameworkCore.Examples/UsersServiceTest.cs
@@ -221,6 +221,31 @@
             Assert.Equal(allUsers, result);
         }
 
+        [Theory]
+        [MemberData(nameof(CancellationTokens))]
+        public async Task Given_ListOfUsers_When_FindOneUserAsync_Then_ThatUserIsReturned(CancellationToken cancellationToken)
+        {
+            // Arrange
+            var users = new List<User>
+            {
+                Fixture.Build<User>().Create(),
+                Fixture.Build<User>().Create(),
+                Fixture.Build<User>().Create()
+            };
+            var usersContextMock = new Mock<UsersContext>();
+            usersContextMock
+                .Setup(x => x.Set<User>())
+                .ReturnsDbSet(users, findByKeyExpression: u => u.Id); //findByKeyExpression is necessary to mock FindAsync
+
+            var usersService = new UsersService(usersContextMock.Object);
+
+            // Act
+            var result = await usersService.FindOneUserAsync(users[0].Id, cancellationToken);
+
+            // Assert
+            Assert.Equal(users[0], result);
+        }
+
         private static IList<User> GenerateNotLockedUsers()
         {
             IList<User> users = new List<User>

--- a/src/Moq.EntityFrameworkCore.Tests/FindAsyncTests.cs
+++ b/src/Moq.EntityFrameworkCore.Tests/FindAsyncTests.cs
@@ -1,6 +1,5 @@
 namespace Moq.EntityFrameworkCore.Tests
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -96,34 +95,6 @@ namespace Moq.EntityFrameworkCore.Tests
         }
 
         [Fact]
-        public void ConfigureMock_WithWrongMockType_ThrowsArgumentException()
-        {
-            // Arrange
-            var wrongMock = new Mock<DbSet<TestEntityForWrongMockType>>();
-
-            // Act
-            var act = () => MoqExtensions.ConfigureMock(wrongMock, new List<TestEntitySimpleKey>(), findByKeyExpression: e => [e.Id]);
-
-            // Assert
-            var ex = Assert.Throws<ArgumentException>(act);
-            Assert.Equal("dbSetMock", ex.ParamName);
-        }
-
-        [Fact]
-        public void ConfigureMockDynamic_WithWrongMockType_ThrowsArgumentException()
-        {
-            // Arrange
-            var wrongMock = new Mock<DbSet<TestEntityForWrongMockType>>();
-
-            // Act
-            var act = () => MoqExtensionsDynamic.ConfigureMockDynamic(wrongMock, new List<TestEntitySimpleKey>(), findByKeyExpression: e => [e.Id]);
-
-            // Assert
-            var ex = Assert.Throws<ArgumentException>(act);
-            Assert.Equal("dbSetMock", ex.ParamName);
-        }
-
-        [Fact]
         public async Task FindAsync_WithCompositeKey_ReturnsCorrectEntity()
         {
             // Arrange
@@ -188,6 +159,71 @@ namespace Moq.EntityFrameworkCore.Tests
             Assert.Null(result);
         }
 
+        [Fact]
+        public async Task FindAsync_Dynamic_WithMatchingKey_ReturnsCorrectEntity()
+        {
+            // Arrange
+            var entities = new List<TestEntitySimpleKey>
+            {
+                new() { Id = 1, Name = "Alice" },
+                new() { Id = 2, Name = "Bob" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntitySimpleKey>>();
+            MoqExtensionsDynamic.ConfigureMockDynamic(dbSetMock, entities, findByKeyExpression: e => [e.Id]);
+
+            // Act
+            var result = await dbSetMock.Object.FindAsync(2);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Bob", result.Name);
+        }
+
+        [Fact]
+        public async Task FindAsync_Dynamic_WithCancellationToken_ReturnsCorrectEntity()
+        {
+            // Arrange
+            var entities = new List<TestEntitySimpleKey>
+            {
+                new() { Id = 1, Name = "Alice" },
+                new() { Id = 2, Name = "Bob" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntitySimpleKey>>();
+            MoqExtensionsDynamic.ConfigureMockDynamic(dbSetMock, entities, findByKeyExpression: e => [e.Id]);
+
+            using var cts = new CancellationTokenSource();
+
+            // Act
+            var result = await dbSetMock.Object.FindAsync([1], cts.Token);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Alice", result.Name);
+        }
+
+        [Fact]
+        public async Task FindAsync_Dynamic_WithCompositeKey_ReturnsCorrectEntity()
+        {
+            // Arrange
+            var entities = new List<TestEntityCompositeKey>
+            {
+                new() { CountryCode = "ES", CityId = 1, Name = "Madrid" },
+                new() { CountryCode = "FR", CityId = 1, Name = "Paris" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntityCompositeKey>>();
+            MoqExtensionsDynamic.ConfigureMockDynamic(dbSetMock, entities, findByKeyExpression: e => [e.CountryCode, e.CityId]);
+
+            // Act
+            var result = await dbSetMock.Object.FindAsync("ES", 1);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Madrid", result.Name);
+        }
+
         public class TestEntitySimpleKey
         {
             public int Id { get; set; }
@@ -199,11 +235,6 @@ namespace Moq.EntityFrameworkCore.Tests
             public string CountryCode { get; set; } = string.Empty;
             public int CityId { get; set; }
             public string Name { get; set; } = string.Empty;
-        }
-
-        public class TestEntityForWrongMockType
-        {
-            public int Id { get; set; }
         }
     }
 }

--- a/src/Moq.EntityFrameworkCore.Tests/FindAsyncTests.cs
+++ b/src/Moq.EntityFrameworkCore.Tests/FindAsyncTests.cs
@@ -1,0 +1,102 @@
+namespace Moq.EntityFrameworkCore.Tests
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.EntityFrameworkCore;
+    using Xunit;
+
+    public class FindAsyncTests
+    {
+        [Fact]
+        public async Task FindAsync_WithMatchingKey_ReturnsCorrectEntity()
+        {
+            // Arrange
+            var entities = new List<TestEntity>
+            {
+                new() { Id = 1, Name = "Alice" },
+                new() { Id = 2, Name = "Bob" },
+                new() { Id = 3, Name = "Charlie" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntity>>();
+            MoqExtensions.ConfigureMock(dbSetMock, entities, findByKeyExpression: e => e.Id);
+
+            // Act
+            var result = await dbSetMock.Object.FindAsync(2);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Bob", result.Name);
+        }
+
+        [Fact]
+        public async Task FindAsync_WithNonMatchingKey_ReturnsNull()
+        {
+            // Arrange
+            var entities = new List<TestEntity>
+            {
+                new() { Id = 1, Name = "Alice" },
+                new() { Id = 2, Name = "Bob" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntity>>();
+            MoqExtensions.ConfigureMock(dbSetMock, entities, findByKeyExpression: e => e.Id);
+
+            // Act
+            var result = await dbSetMock.Object.FindAsync(999);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task FindAsync_WithCancellationToken_ReturnsCorrectEntity()
+        {
+            // Arrange
+            var entities = new List<TestEntity>
+            {
+                new() { Id = 1, Name = "Alice" },
+                new() { Id = 2, Name = "Bob" },
+                new() { Id = 3, Name = "Charlie" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntity>>();
+            MoqExtensions.ConfigureMock(dbSetMock, entities, findByKeyExpression: e => e.Id);
+
+            using var cts = new CancellationTokenSource();
+
+            // Act
+            var result = await dbSetMock.Object.FindAsync(new object[] { 3 }, cts.Token);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Charlie", result.Name);
+        }
+
+        [Fact]
+        public async Task FindAsync_WithoutFindByKeyExpression_ReturnsDefault()
+        {
+            // Arrange
+            var entities = new List<TestEntity>
+            {
+                new() { Id = 1, Name = "Alice" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntity>>();
+            MoqExtensions.ConfigureMock(dbSetMock, entities); // no findByKeyExpression
+
+            // Act
+            var result = await dbSetMock.Object.FindAsync(1);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        public class TestEntity
+        {
+            public int Id { get; set; }
+            public string Name { get; set; } = string.Empty;
+        }
+    }
+}

--- a/src/Moq.EntityFrameworkCore.Tests/FindAsyncTests.cs
+++ b/src/Moq.EntityFrameworkCore.Tests/FindAsyncTests.cs
@@ -1,5 +1,6 @@
 namespace Moq.EntityFrameworkCore.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -156,6 +157,33 @@ namespace Moq.EntityFrameworkCore.Tests
             var result = await dbSetMock.Object.FindAsync("DE", 1);
 
             // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ConfigureMock_NullFindByKeyExpression_ThrowsArgumentNullException()
+        {
+            var dbSetMock = new Mock<DbSet<TestEntitySimpleKey>>();
+            Assert.Throws<ArgumentNullException>(() =>
+                MoqExtensions.ConfigureMock(dbSetMock, new List<TestEntitySimpleKey>(), findByKeyExpression: null!));
+        }
+
+        [Fact]
+        public void ConfigureMockDynamic_NullFindByKeyExpression_ThrowsArgumentNullException()
+        {
+            var dbSetMock = new Mock<DbSet<TestEntitySimpleKey>>();
+            Assert.Throws<ArgumentNullException>(() =>
+                MoqExtensionsDynamic.ConfigureMockDynamic(dbSetMock, new List<TestEntitySimpleKey>(), findByKeyExpression: null!));
+        }
+
+        [Fact]
+        public async Task FindAsync_EmptyCollection_ReturnsNull()
+        {
+            var dbSetMock = new Mock<DbSet<TestEntitySimpleKey>>();
+            MoqExtensions.ConfigureMock(dbSetMock, new List<TestEntitySimpleKey>(), findByKeyExpression: e => [e.Id]);
+
+            var result = await dbSetMock.Object.FindAsync(1);
+
             Assert.Null(result);
         }
 

--- a/src/Moq.EntityFrameworkCore.Tests/FindAsyncTests.cs
+++ b/src/Moq.EntityFrameworkCore.Tests/FindAsyncTests.cs
@@ -1,9 +1,11 @@
 namespace Moq.EntityFrameworkCore.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
+    using Dynamic;
     using Xunit;
 
     public class FindAsyncTests
@@ -12,15 +14,15 @@ namespace Moq.EntityFrameworkCore.Tests
         public async Task FindAsync_WithMatchingKey_ReturnsCorrectEntity()
         {
             // Arrange
-            var entities = new List<TestEntity>
+            var entities = new List<TestEntitySimpleKey>
             {
                 new() { Id = 1, Name = "Alice" },
                 new() { Id = 2, Name = "Bob" },
                 new() { Id = 3, Name = "Charlie" }
             };
 
-            var dbSetMock = new Mock<DbSet<TestEntity>>();
-            MoqExtensions.ConfigureMock(dbSetMock, entities, findByKeyExpression: e => e.Id);
+            var dbSetMock = new Mock<DbSet<TestEntitySimpleKey>>();
+            MoqExtensions.ConfigureMock(dbSetMock, entities, findByKeyExpression: e => [e.Id]);
 
             // Act
             var result = await dbSetMock.Object.FindAsync(2);
@@ -34,14 +36,14 @@ namespace Moq.EntityFrameworkCore.Tests
         public async Task FindAsync_WithNonMatchingKey_ReturnsNull()
         {
             // Arrange
-            var entities = new List<TestEntity>
+            var entities = new List<TestEntitySimpleKey>
             {
                 new() { Id = 1, Name = "Alice" },
                 new() { Id = 2, Name = "Bob" }
             };
 
-            var dbSetMock = new Mock<DbSet<TestEntity>>();
-            MoqExtensions.ConfigureMock(dbSetMock, entities, findByKeyExpression: e => e.Id);
+            var dbSetMock = new Mock<DbSet<TestEntitySimpleKey>>();
+            MoqExtensions.ConfigureMock(dbSetMock, entities, findByKeyExpression: e => [e.Id]);
 
             // Act
             var result = await dbSetMock.Object.FindAsync(999);
@@ -54,20 +56,20 @@ namespace Moq.EntityFrameworkCore.Tests
         public async Task FindAsync_WithCancellationToken_ReturnsCorrectEntity()
         {
             // Arrange
-            var entities = new List<TestEntity>
+            var entities = new List<TestEntitySimpleKey>
             {
                 new() { Id = 1, Name = "Alice" },
                 new() { Id = 2, Name = "Bob" },
                 new() { Id = 3, Name = "Charlie" }
             };
 
-            var dbSetMock = new Mock<DbSet<TestEntity>>();
-            MoqExtensions.ConfigureMock(dbSetMock, entities, findByKeyExpression: e => e.Id);
+            var dbSetMock = new Mock<DbSet<TestEntitySimpleKey>>();
+            MoqExtensions.ConfigureMock(dbSetMock, entities, findByKeyExpression: e => [e.Id]);
 
             using var cts = new CancellationTokenSource();
 
             // Act
-            var result = await dbSetMock.Object.FindAsync(new object[] { 3 }, cts.Token);
+            var result = await dbSetMock.Object.FindAsync([3], cts.Token);
 
             // Assert
             Assert.NotNull(result);
@@ -78,12 +80,12 @@ namespace Moq.EntityFrameworkCore.Tests
         public async Task FindAsync_WithoutFindByKeyExpression_ReturnsDefault()
         {
             // Arrange
-            var entities = new List<TestEntity>
+            var entities = new List<TestEntitySimpleKey>
             {
                 new() { Id = 1, Name = "Alice" }
             };
 
-            var dbSetMock = new Mock<DbSet<TestEntity>>();
+            var dbSetMock = new Mock<DbSet<TestEntitySimpleKey>>();
             MoqExtensions.ConfigureMock(dbSetMock, entities); // no findByKeyExpression
 
             // Act
@@ -93,10 +95,115 @@ namespace Moq.EntityFrameworkCore.Tests
             Assert.Null(result);
         }
 
-        public class TestEntity
+        [Fact]
+        public void ConfigureMock_WithWrongMockType_ThrowsArgumentException()
+        {
+            // Arrange
+            var wrongMock = new Mock<DbSet<TestEntityForWrongMockType>>();
+
+            // Act
+            var act = () => MoqExtensions.ConfigureMock(wrongMock, new List<TestEntitySimpleKey>(), findByKeyExpression: e => [e.Id]);
+
+            // Assert
+            var ex = Assert.Throws<ArgumentException>(act);
+            Assert.Equal("dbSetMock", ex.ParamName);
+        }
+
+        [Fact]
+        public void ConfigureMockDynamic_WithWrongMockType_ThrowsArgumentException()
+        {
+            // Arrange
+            var wrongMock = new Mock<DbSet<TestEntityForWrongMockType>>();
+
+            // Act
+            var act = () => MoqExtensionsDynamic.ConfigureMockDynamic(wrongMock, new List<TestEntitySimpleKey>(), findByKeyExpression: e => [e.Id]);
+
+            // Assert
+            var ex = Assert.Throws<ArgumentException>(act);
+            Assert.Equal("dbSetMock", ex.ParamName);
+        }
+
+        [Fact]
+        public async Task FindAsync_WithCompositeKey_ReturnsCorrectEntity()
+        {
+            // Arrange
+            var entities = new List<TestEntityCompositeKey>
+            {
+                new() { CountryCode = "ES", CityId = 1, Name = "Madrid" },
+                new() { CountryCode = "ES", CityId = 2, Name = "Barcelona" },
+                new() { CountryCode = "FR", CityId = 1, Name = "Paris" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntityCompositeKey>>();
+            MoqExtensions.ConfigureMock(dbSetMock, entities, findByKeyExpression: e => [e.CountryCode, e.CityId]);
+
+            // Act
+            var result = await dbSetMock.Object.FindAsync("FR", 1);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Paris", result.Name);
+        }
+
+        [Fact]
+        public async Task FindAsync_WithCompositeKey_KeyValuesInWrongOrder_ReturnsNull()
+        {
+            // Arrange
+            var entities = new List<TestEntityCompositeKey>
+            {
+                new() { CountryCode = "FR", CityId = 1, Name = "Paris" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntityCompositeKey>>();
+            MoqExtensions.ConfigureMock(dbSetMock, entities, findByKeyExpression: e => [e.CountryCode, e.CityId]);
+
+            // Act — key values passed in reverse order: (1, "FR") instead of ("FR", 1).
+            // The order must be consistent with the findByKeyExpression lambda (e => [e.CountryCode, e.CityId]).
+            // This is analogous to EF Core's own FindAsync contract: when using a real DbContext,
+            // key values must be supplied in the same order as the key properties are declared in the model.
+            // Passing them out of order produces no match, which is the expected and correct result.
+            var result = await dbSetMock.Object.FindAsync(1, "FR");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task FindAsync_WithCompositeKey_DoesNotMatchPartialKey()
+        {
+            // Arrange
+            var entities = new List<TestEntityCompositeKey>
+            {
+                new() { CountryCode = "ES", CityId = 1, Name = "Madrid" },
+                new() { CountryCode = "FR", CityId = 1, Name = "Paris" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntityCompositeKey>>();
+            MoqExtensions.ConfigureMock(dbSetMock, entities, findByKeyExpression: e => [e.CountryCode, e.CityId]);
+
+            // Act
+            var result = await dbSetMock.Object.FindAsync("DE", 1);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        public class TestEntitySimpleKey
         {
             public int Id { get; set; }
             public string Name { get; set; } = string.Empty;
+        }
+
+        public class TestEntityCompositeKey
+        {
+            public string CountryCode { get; set; } = string.Empty;
+            public int CityId { get; set; }
+            public string Name { get; set; } = string.Empty;
+        }
+
+        public class TestEntityForWrongMockType
+        {
+            public int Id { get; set; }
         }
     }
 }

--- a/src/Moq.EntityFrameworkCore.Tests/FindAsyncTests.cs
+++ b/src/Moq.EntityFrameworkCore.Tests/FindAsyncTests.cs
@@ -160,6 +160,25 @@ namespace Moq.EntityFrameworkCore.Tests
         }
 
         [Fact]
+        public async Task FindAsync_Dynamic_WithoutFindByKeyExpression_ReturnsDefault()
+        {
+            // Arrange
+            var entities = new List<TestEntitySimpleKey>
+            {
+                new() { Id = 1, Name = "Alice" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntitySimpleKey>>();
+            MoqExtensionsDynamic.ConfigureMockDynamic(dbSetMock, entities); // no findByKeyExpression
+
+            // Act
+            var result = await dbSetMock.Object.FindAsync(1);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
         public async Task FindAsync_Dynamic_WithMatchingKey_ReturnsCorrectEntity()
         {
             // Arrange
@@ -222,6 +241,45 @@ namespace Moq.EntityFrameworkCore.Tests
             // Assert
             Assert.NotNull(result);
             Assert.Equal("Madrid", result.Name);
+        }
+
+        [Fact]
+        public async Task FindAsync_Dynamic_WithCompositeKey_KeyValuesInWrongOrder_ReturnsNull()
+        {
+            // Arrange
+            var entities = new List<TestEntityCompositeKey>
+            {
+                new() { CountryCode = "FR", CityId = 1, Name = "Paris" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntityCompositeKey>>();
+            MoqExtensionsDynamic.ConfigureMockDynamic(dbSetMock, entities, findByKeyExpression: e => [e.CountryCode, e.CityId]);
+
+            // Act
+            var result = await dbSetMock.Object.FindAsync(1, "FR");
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task FindAsync_Dynamic_WithCompositeKey_DoesNotMatchPartialKey()
+        {
+            // Arrange
+            var entities = new List<TestEntityCompositeKey>
+            {
+                new() { CountryCode = "ES", CityId = 1, Name = "Madrid" },
+                new() { CountryCode = "FR", CityId = 1, Name = "Paris" }
+            };
+
+            var dbSetMock = new Mock<DbSet<TestEntityCompositeKey>>();
+            MoqExtensionsDynamic.ConfigureMockDynamic(dbSetMock, entities, findByKeyExpression: e => [e.CountryCode, e.CityId]);
+
+            // Act
+            var result = await dbSetMock.Object.FindAsync("DE", 1);
+
+            // Assert
+            Assert.Null(result);
         }
 
         public class TestEntitySimpleKey

--- a/src/Moq.EntityFrameworkCore/Dynamic/GlobalFilterDbSetExtensionsDynamic.cs
+++ b/src/Moq.EntityFrameworkCore/Dynamic/GlobalFilterDbSetExtensionsDynamic.cs
@@ -12,7 +12,7 @@
             this ISetup<TContext, DbSet<TEntity>> setup,
             IEnumerable<TEntity> entities,
             Func<TEntity, bool> filter,
-            Func<TEntity, object>? findByKeyExpression = null
+            Func<TEntity, object[]>? findByKeyExpression = null
         )
             where TContext : DbContext
             where TEntity : class

--- a/src/Moq.EntityFrameworkCore/Dynamic/GlobalFilterDbSetExtensionsDynamic.cs
+++ b/src/Moq.EntityFrameworkCore/Dynamic/GlobalFilterDbSetExtensionsDynamic.cs
@@ -11,13 +11,14 @@
         public static IReturnsResult<TContext> ReturnsDbSetWithGlobalFilterDynamic<TContext, TEntity>(
             this ISetup<TContext, DbSet<TEntity>> setup,
             IEnumerable<TEntity> entities,
-            Func<TEntity, bool> filter
+            Func<TEntity, bool> filter,
+            Func<TEntity, object>? findByKeyExpression = null
         )
             where TContext : DbContext
             where TEntity : class
         {
             var filtered = entities.Where(filter).ToList();
-            return setup.ReturnsDbSetDynamic(filtered);
+            return setup.ReturnsDbSetDynamic(filtered, findByKeyExpression: findByKeyExpression);
         }
     }
 }

--- a/src/Moq.EntityFrameworkCore/Dynamic/GlobalFilterDbSetExtensionsDynamic.cs
+++ b/src/Moq.EntityFrameworkCore/Dynamic/GlobalFilterDbSetExtensionsDynamic.cs
@@ -24,7 +24,7 @@ namespace Moq.EntityFrameworkCore.Dynamic
             this ISetup<TContext, DbSet<TEntity>> setup,
             IEnumerable<TEntity> entities,
             Func<TEntity, bool> filter,
-            Func<TEntity, object[]> findByKeyExpression
+            Func<TEntity, object?[]> findByKeyExpression
         )
             where TContext : DbContext
             where TEntity : class

--- a/src/Moq.EntityFrameworkCore/Dynamic/GlobalFilterDbSetExtensionsDynamic.cs
+++ b/src/Moq.EntityFrameworkCore/Dynamic/GlobalFilterDbSetExtensionsDynamic.cs
@@ -1,4 +1,4 @@
-﻿namespace Moq.EntityFrameworkCore.Dynamic
+namespace Moq.EntityFrameworkCore.Dynamic
 {
     using Microsoft.EntityFrameworkCore;
     using System;
@@ -11,14 +11,26 @@
         public static IReturnsResult<TContext> ReturnsDbSetWithGlobalFilterDynamic<TContext, TEntity>(
             this ISetup<TContext, DbSet<TEntity>> setup,
             IEnumerable<TEntity> entities,
-            Func<TEntity, bool> filter,
-            Func<TEntity, object[]>? findByKeyExpression = null
+            Func<TEntity, bool> filter
         )
             where TContext : DbContext
             where TEntity : class
         {
             var filtered = entities.Where(filter).ToList();
-            return setup.ReturnsDbSetDynamic(filtered, findByKeyExpression: findByKeyExpression);
+            return setup.ReturnsDbSetDynamic(filtered);
+        }
+
+        public static IReturnsResult<TContext> ReturnsDbSetWithGlobalFilterDynamic<TContext, TEntity>(
+            this ISetup<TContext, DbSet<TEntity>> setup,
+            IEnumerable<TEntity> entities,
+            Func<TEntity, bool> filter,
+            Func<TEntity, object[]> findByKeyExpression
+        )
+            where TContext : DbContext
+            where TEntity : class
+        {
+            var filtered = entities.Where(filter).ToList();
+            return setup.ReturnsDbSetDynamic(filtered, findByKeyExpression);
         }
     }
 }

--- a/src/Moq.EntityFrameworkCore/Dynamic/MoqExtensionsDynamic.cs
+++ b/src/Moq.EntityFrameworkCore/Dynamic/MoqExtensionsDynamic.cs
@@ -1,4 +1,4 @@
-﻿namespace Moq.EntityFrameworkCore.Dynamic
+namespace Moq.EntityFrameworkCore.Dynamic
 {
     using System;
     using System.Collections.Generic;
@@ -12,27 +12,54 @@
 
     public static class MoqExtensionsDynamic
     {
-        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object[]>? findByKeyExpression = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
         {
-            dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
+            dbSetMock ??= new Mock<DbSet<TEntity>>();
+
+            ConfigureMockDynamic(dbSetMock, entities);
+
+            return setupResult.Returns(() => dbSetMock.Object);
+        }
+
+        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
+        {
+            dbSetMock ??= new Mock<DbSet<TEntity>>();
 
             ConfigureMockDynamic(dbSetMock, entities, findByKeyExpression);
 
             return setupResult.Returns(() => dbSetMock.Object);
         }
 
-        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object[]>? findByKeyExpression = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
         {
-            dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
+            dbSetMock ??= new Mock<DbSet<TEntity>>();
+
+            ConfigureMockDynamic(dbSetMock, entities);
+
+            return setupResult.Returns(() => dbSetMock.Object);
+        }
+
+        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
+        {
+            dbSetMock ??= new Mock<DbSet<TEntity>>();
 
             ConfigureMockDynamic(dbSetMock, entities, findByKeyExpression);
 
             return setupResult.Returns(() => dbSetMock.Object);
         }
 
-        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSetDynamic<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object[]>? findByKeyExpression = null) where TEntity : class
+        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSetDynamic<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null) where TEntity : class
         {
-            dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
+            dbSetMock ??= new Mock<DbSet<TEntity>>();
+
+            ConfigureMockDynamic(dbSetMock, entities);
+
+            return setupResult.Returns(() => dbSetMock.Object);
+        }
+
+        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSetDynamic<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where TEntity : class
+        {
+            dbSetMock ??= new Mock<DbSet<TEntity>>();
 
             ConfigureMockDynamic(dbSetMock, entities, findByKeyExpression);
 
@@ -62,11 +89,9 @@
         /// <summary>
         /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queryable via LINQ
         /// </summary>
-        public static void ConfigureMockDynamic<TEntity>(Mock<DbSet<TEntity>> dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object[]>? findByKeyExpression = null) where TEntity : class
+        public static void ConfigureMockDynamic<TEntity>(Mock<DbSet<TEntity>> dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression) where TEntity : class
         {
             ConfigureMockDynamic((Mock)dbSetMock, entities);
-
-            if (findByKeyExpression is null) return;
 
             dbSetMock
                 .Setup(m => m.FindAsync(It.IsAny<object?[]?>()))

--- a/src/Moq.EntityFrameworkCore/Dynamic/MoqExtensionsDynamic.cs
+++ b/src/Moq.EntityFrameworkCore/Dynamic/MoqExtensionsDynamic.cs
@@ -12,7 +12,7 @@
 
     public static class MoqExtensionsDynamic
     {
-        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object>? findByKeyExpression = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object[]>? findByKeyExpression = null) where T : class where TEntity : class
         {
             dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
 
@@ -21,7 +21,7 @@
             return setupResult.Returns(() => dbSetMock.Object);
         }
 
-        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object>? findByKeyExpression = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object[]>? findByKeyExpression = null) where T : class where TEntity : class
         {
             dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
 
@@ -30,7 +30,7 @@
             return setupResult.Returns(() => dbSetMock.Object);
         }
 
-        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSetDynamic<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object>? findByKeyExpression = null) where TEntity : class
+        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSetDynamic<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object[]>? findByKeyExpression = null) where TEntity : class
         {
             dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
 
@@ -42,7 +42,7 @@
         /// <summary>
         /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queriable via LINQ
         /// </summary>
-        public static void ConfigureMockDynamic<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object>? findByKeyExpression = null) where TEntity : class
+        public static void ConfigureMockDynamic<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object[]>? findByKeyExpression = null) where TEntity : class
         {
             var entitiesAsQueryable = entities.AsQueryable();
 
@@ -58,16 +58,19 @@
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(entitiesAsQueryable.ElementType);
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(() => entitiesAsQueryable.GetEnumerator());
 
-            if (findByKeyExpression != null)
+            if (findByKeyExpression is not null)
             {
-                var typedMock = (Mock<DbSet<TEntity>>)dbSetMock;
+                if (dbSetMock is not Mock<DbSet<TEntity>> typedMock)
+                {
+                    throw new ArgumentException($"dbSetMock must be a Mock<DbSet<{typeof(TEntity).Name}>> when findByKeyExpression is provided.", nameof(dbSetMock));
+                }
 
                 typedMock
                     .Setup(m => m.FindAsync(It.IsAny<object?[]?>()))
                     .Returns<object?[]?>(keyValues =>
                     {
                         if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
-                        return ValueTask.FromResult(entities.FirstOrDefault(e => Equals(findByKeyExpression(e), keyValues[0])));
+                        return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
                     });
 
                 typedMock
@@ -75,7 +78,7 @@
                     .Returns<object?[]?, CancellationToken>((keyValues, _) =>
                     {
                         if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
-                        return ValueTask.FromResult(entities.FirstOrDefault(e => Equals(findByKeyExpression(e), keyValues[0])));
+                        return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
                     });
             }
         }

--- a/src/Moq.EntityFrameworkCore/Dynamic/MoqExtensionsDynamic.cs
+++ b/src/Moq.EntityFrameworkCore/Dynamic/MoqExtensionsDynamic.cs
@@ -40,15 +40,15 @@
         }
 
         /// <summary>
-        /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queriable via LINQ
+        /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queryable via LINQ
         /// </summary>
-        public static void ConfigureMockDynamic<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object[]>? findByKeyExpression = null) where TEntity : class
+        public static void ConfigureMockDynamic<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities) where TEntity : class
         {
             var entitiesAsQueryable = entities.AsQueryable();
 
             dbSetMock.As<IAsyncEnumerable<TEntity>>()
-               .Setup(m => m.GetAsyncEnumerator(CancellationToken.None))
-               .Returns(() => new InMemoryDbAsyncEnumerator<TEntity>(entitiesAsQueryable.GetEnumerator()));
+                .Setup(m => m.GetAsyncEnumerator(CancellationToken.None))
+                .Returns(() => new InMemoryDbAsyncEnumerator<TEntity>(entitiesAsQueryable.GetEnumerator()));
 
             dbSetMock.As<IQueryable<TEntity>>()
                 .Setup(m => m.Provider)
@@ -57,30 +57,32 @@
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(entitiesAsQueryable.Expression);
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(entitiesAsQueryable.ElementType);
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(() => entitiesAsQueryable.GetEnumerator());
+        }
 
-            if (findByKeyExpression is not null)
-            {
-                if (dbSetMock is not Mock<DbSet<TEntity>> typedMock)
+        /// <summary>
+        /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queryable via LINQ
+        /// </summary>
+        public static void ConfigureMockDynamic<TEntity>(Mock<DbSet<TEntity>> dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object[]>? findByKeyExpression = null) where TEntity : class
+        {
+            ConfigureMockDynamic((Mock)dbSetMock, entities);
+
+            if (findByKeyExpression is null) return;
+
+            dbSetMock
+                .Setup(m => m.FindAsync(It.IsAny<object?[]?>()))
+                .Returns<object?[]?>(keyValues =>
                 {
-                    throw new ArgumentException($"dbSetMock must be a Mock<DbSet<{typeof(TEntity).Name}>> when findByKeyExpression is provided.", nameof(dbSetMock));
-                }
+                    if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
+                    return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
+                });
 
-                typedMock
-                    .Setup(m => m.FindAsync(It.IsAny<object?[]?>()))
-                    .Returns<object?[]?>(keyValues =>
-                    {
-                        if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
-                        return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
-                    });
-
-                typedMock
-                    .Setup(m => m.FindAsync(It.IsAny<object?[]?>(), It.IsAny<CancellationToken>()))
-                    .Returns<object?[]?, CancellationToken>((keyValues, _) =>
-                    {
-                        if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
-                        return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
-                    });
-            }
+            dbSetMock
+                .Setup(m => m.FindAsync(It.IsAny<object?[]?>(), It.IsAny<CancellationToken>()))
+                .Returns<object?[]?, CancellationToken>((keyValues, _) =>
+                {
+                    if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
+                    return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
+                });
         }
     }
 }

--- a/src/Moq.EntityFrameworkCore/Dynamic/MoqExtensionsDynamic.cs
+++ b/src/Moq.EntityFrameworkCore/Dynamic/MoqExtensionsDynamic.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
     using Moq.EntityFrameworkCore.DbAsyncQueryProvider;
     using Moq.Language;
@@ -11,29 +12,29 @@
 
     public static class MoqExtensionsDynamic
     {
-        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object>? findByKeyExpression = null) where T : class where TEntity : class
         {
             dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
 
-            ConfigureMockDynamic(dbSetMock, entities);
+            ConfigureMockDynamic(dbSetMock, entities, findByKeyExpression);
 
             return setupResult.Returns(() => dbSetMock.Object);
         }
 
-        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object>? findByKeyExpression = null) where T : class where TEntity : class
         {
             dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
 
-            ConfigureMockDynamic(dbSetMock, entities);
+            ConfigureMockDynamic(dbSetMock, entities, findByKeyExpression);
 
             return setupResult.Returns(() => dbSetMock.Object);
         }
 
-        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSetDynamic<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null) where TEntity : class
+        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSetDynamic<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object>? findByKeyExpression = null) where TEntity : class
         {
             dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
 
-            ConfigureMockDynamic(dbSetMock, entities);
+            ConfigureMockDynamic(dbSetMock, entities, findByKeyExpression);
 
             return setupResult.Returns(() => dbSetMock.Object);
         }
@@ -41,7 +42,7 @@
         /// <summary>
         /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queriable via LINQ
         /// </summary>
-        public static void ConfigureMockDynamic<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities) where TEntity : class
+        public static void ConfigureMockDynamic<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object>? findByKeyExpression = null) where TEntity : class
         {
             var entitiesAsQueryable = entities.AsQueryable();
 
@@ -56,6 +57,27 @@
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(entitiesAsQueryable.Expression);
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(entitiesAsQueryable.ElementType);
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(() => entitiesAsQueryable.GetEnumerator());
+
+            if (findByKeyExpression != null)
+            {
+                var typedMock = (Mock<DbSet<TEntity>>)dbSetMock;
+
+                typedMock
+                    .Setup(m => m.FindAsync(It.IsAny<object?[]?>()))
+                    .Returns<object?[]?>(keyValues =>
+                    {
+                        if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
+                        return ValueTask.FromResult(entities.FirstOrDefault(e => Equals(findByKeyExpression(e), keyValues[0])));
+                    });
+
+                typedMock
+                    .Setup(m => m.FindAsync(It.IsAny<object?[]?>(), It.IsAny<CancellationToken>()))
+                    .Returns<object?[]?, CancellationToken>((keyValues, _) =>
+                    {
+                        if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
+                        return ValueTask.FromResult(entities.FirstOrDefault(e => Equals(findByKeyExpression(e), keyValues[0])));
+                    });
+            }
         }
     }
 }

--- a/src/Moq.EntityFrameworkCore/Dynamic/MoqExtensionsDynamic.cs
+++ b/src/Moq.EntityFrameworkCore/Dynamic/MoqExtensionsDynamic.cs
@@ -21,7 +21,7 @@ namespace Moq.EntityFrameworkCore.Dynamic
             return setupResult.Returns(() => dbSetMock.Object);
         }
 
-        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object?[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
         {
             dbSetMock ??= new Mock<DbSet<TEntity>>();
 
@@ -39,7 +39,7 @@ namespace Moq.EntityFrameworkCore.Dynamic
             return setupResult.Returns(() => dbSetMock.Object);
         }
 
-        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSetDynamic<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object?[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
         {
             dbSetMock ??= new Mock<DbSet<TEntity>>();
 
@@ -57,7 +57,7 @@ namespace Moq.EntityFrameworkCore.Dynamic
             return setupResult.Returns(() => dbSetMock.Object);
         }
 
-        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSetDynamic<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where TEntity : class
+        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSetDynamic<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object?[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where TEntity : class
         {
             dbSetMock ??= new Mock<DbSet<TEntity>>();
 
@@ -88,17 +88,31 @@ namespace Moq.EntityFrameworkCore.Dynamic
 
         /// <summary>
         /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queryable via LINQ
+        /// and mocks <see cref="DbSet{TEntity}.FindAsync(object?[])"/> using the provided key expression.
         /// </summary>
-        public static void ConfigureMockDynamic<TEntity>(Mock<DbSet<TEntity>> dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression) where TEntity : class
+        /// <param name="dbSetMock">The mock to configure.</param>
+        /// <param name="entities">The entities to use as the data source.</param>
+        /// <param name="findByKeyExpression">
+        /// A delegate that extracts the key values from an entity. The values must be returned in the same
+        /// order as they are passed to <see cref="DbSet{TEntity}.FindAsync(object?[])"/>, matching the
+        /// order of the key properties in the EF Core model.
+        /// </param>
+        public static void ConfigureMockDynamic<TEntity>(Mock<DbSet<TEntity>> dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object?[]> findByKeyExpression) where TEntity : class
         {
-            ConfigureMockDynamic((Mock)dbSetMock, entities);
+            ArgumentNullException.ThrowIfNull(findByKeyExpression);
+
+            // Materialise once so that both the LINQ queryable and FindAsync lambdas
+            // operate on the same snapshot and single-use enumerables are safe.
+            var entitiesList = entities.ToList();
+
+            ConfigureMockDynamic((Mock)dbSetMock, entitiesList);
 
             dbSetMock
                 .Setup(m => m.FindAsync(It.IsAny<object?[]?>()))
                 .Returns<object?[]?>(keyValues =>
                 {
                     if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
-                    return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
+                    return ValueTask.FromResult(entitiesList.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
                 });
 
             dbSetMock
@@ -106,7 +120,7 @@ namespace Moq.EntityFrameworkCore.Dynamic
                 .Returns<object?[]?, CancellationToken>((keyValues, _) =>
                 {
                     if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
-                    return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
+                    return ValueTask.FromResult(entitiesList.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
                 });
         }
     }

--- a/src/Moq.EntityFrameworkCore/GlobalFilterDbSetExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/GlobalFilterDbSetExtensions.cs
@@ -24,7 +24,7 @@ namespace Moq.EntityFrameworkCore
             this ISetup<TContext, DbSet<TEntity>> setup,
             IEnumerable<TEntity> entities,
             Func<TEntity, bool> filter,
-            Func<TEntity, object[]> findByKeyExpression
+            Func<TEntity, object?[]> findByKeyExpression
         )
             where TContext : DbContext
             where TEntity : class

--- a/src/Moq.EntityFrameworkCore/GlobalFilterDbSetExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/GlobalFilterDbSetExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Moq.EntityFrameworkCore
+namespace Moq.EntityFrameworkCore
 {
     using Microsoft.EntityFrameworkCore;
     using System;
@@ -11,14 +11,26 @@
         public static IReturnsResult<TContext> ReturnsDbSetWithGlobalFilter<TContext, TEntity>(
             this ISetup<TContext, DbSet<TEntity>> setup,
             IEnumerable<TEntity> entities,
-            Func<TEntity, bool> filter,
-            Func<TEntity, object[]>? findByKeyExpression = null
+            Func<TEntity, bool> filter
         )
             where TContext : DbContext
             where TEntity : class
         {
             var filtered = entities.Where(filter).ToList();
-            return setup.ReturnsDbSet(filtered, findByKeyExpression: findByKeyExpression);
+            return setup.ReturnsDbSet(filtered);
+        }
+
+        public static IReturnsResult<TContext> ReturnsDbSetWithGlobalFilter<TContext, TEntity>(
+            this ISetup<TContext, DbSet<TEntity>> setup,
+            IEnumerable<TEntity> entities,
+            Func<TEntity, bool> filter,
+            Func<TEntity, object[]> findByKeyExpression
+        )
+            where TContext : DbContext
+            where TEntity : class
+        {
+            var filtered = entities.Where(filter).ToList();
+            return setup.ReturnsDbSet(filtered, findByKeyExpression);
         }
     }
 }

--- a/src/Moq.EntityFrameworkCore/GlobalFilterDbSetExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/GlobalFilterDbSetExtensions.cs
@@ -12,7 +12,7 @@
             this ISetup<TContext, DbSet<TEntity>> setup,
             IEnumerable<TEntity> entities,
             Func<TEntity, bool> filter,
-            Func<TEntity, object>? findByKeyExpression = null
+            Func<TEntity, object[]>? findByKeyExpression = null
         )
             where TContext : DbContext
             where TEntity : class

--- a/src/Moq.EntityFrameworkCore/GlobalFilterDbSetExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/GlobalFilterDbSetExtensions.cs
@@ -11,13 +11,14 @@
         public static IReturnsResult<TContext> ReturnsDbSetWithGlobalFilter<TContext, TEntity>(
             this ISetup<TContext, DbSet<TEntity>> setup,
             IEnumerable<TEntity> entities,
-            Func<TEntity, bool> filter
+            Func<TEntity, bool> filter,
+            Func<TEntity, object>? findByKeyExpression = null
         )
             where TContext : DbContext
             where TEntity : class
         {
             var filtered = entities.Where(filter).ToList();
-            return setup.ReturnsDbSet(filtered);
+            return setup.ReturnsDbSet(filtered, findByKeyExpression: findByKeyExpression);
         }
     }
 }

--- a/src/Moq.EntityFrameworkCore/MoqExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/MoqExtensions.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.EntityFrameworkCore;
     using Moq.EntityFrameworkCore.DbAsyncQueryProvider;
     using Moq.Language;
@@ -11,29 +12,29 @@
 
     public static class MoqExtensions
     {
-        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object>? findByKeyExpression = null) where T : class where TEntity : class
         {
             dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
 
-            ConfigureMock(dbSetMock, entities);
+            ConfigureMock(dbSetMock, entities, findByKeyExpression);
 
             return setupResult.Returns(dbSetMock.Object);
         }
 
-        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object>? findByKeyExpression = null) where T : class where TEntity : class
         {
             dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
 
-            ConfigureMock(dbSetMock, entities);
+            ConfigureMock(dbSetMock, entities, findByKeyExpression);
 
             return setupResult.Returns(dbSetMock.Object);
         }
 
-        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSet<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null) where TEntity : class
+        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSet<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object>? findByKeyExpression = null) where TEntity : class
         {
             dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
 
-            ConfigureMock(dbSetMock, entities);
+            ConfigureMock(dbSetMock, entities, findByKeyExpression);
 
             return setupResult.Returns(dbSetMock.Object);
         }
@@ -41,7 +42,7 @@
         /// <summary>
         /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queriable via LINQ
         /// </summary>
-        public static void ConfigureMock<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities) where TEntity : class
+        public static void ConfigureMock<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object>? findByKeyExpression = null) where TEntity : class
         {
             var entitiesAsQueryable = entities.AsQueryable();
 
@@ -56,6 +57,27 @@
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(entitiesAsQueryable.Expression);
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(entitiesAsQueryable.ElementType);
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(() => entitiesAsQueryable.GetEnumerator());
+
+            if (findByKeyExpression is not null)
+            {
+                var typedMock = (Mock<DbSet<TEntity>>)dbSetMock;
+
+                typedMock
+                    .Setup(m => m.FindAsync(It.IsAny<object?[]?>()))
+                    .Returns<object?[]?>(keyValues =>
+                    {
+                        if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
+                        return ValueTask.FromResult(entities.FirstOrDefault(e => Equals(findByKeyExpression(e), keyValues[0])));
+                    });
+
+                typedMock
+                    .Setup(m => m.FindAsync(It.IsAny<object?[]?>(), It.IsAny<CancellationToken>()))
+                    .Returns<object?[]?, CancellationToken>((keyValues, _) =>
+                    {
+                        if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
+                        return ValueTask.FromResult(entities.FirstOrDefault(e => Equals(findByKeyExpression(e), keyValues[0])));
+                    });
+            }
         }
     }
 }

--- a/src/Moq.EntityFrameworkCore/MoqExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/MoqExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Moq.EntityFrameworkCore
+namespace Moq.EntityFrameworkCore
 {
     using System;
     using System.Collections.Generic;
@@ -12,27 +12,54 @@
 
     public static class MoqExtensions
     {
-        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object[]>? findByKeyExpression = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
         {
-            dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
+            dbSetMock ??= new Mock<DbSet<TEntity>>();
+
+            ConfigureMock(dbSetMock, entities);
+
+            return setupResult.Returns(dbSetMock.Object);
+        }
+
+        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
+        {
+            dbSetMock ??= new Mock<DbSet<TEntity>>();
 
             ConfigureMock(dbSetMock, entities, findByKeyExpression);
 
             return setupResult.Returns(dbSetMock.Object);
         }
 
-        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object[]>? findByKeyExpression = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
         {
-            dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
+            dbSetMock ??= new Mock<DbSet<TEntity>>();
+
+            ConfigureMock(dbSetMock, entities);
+
+            return setupResult.Returns(dbSetMock.Object);
+        }
+
+        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
+        {
+            dbSetMock ??= new Mock<DbSet<TEntity>>();
 
             ConfigureMock(dbSetMock, entities, findByKeyExpression);
 
             return setupResult.Returns(dbSetMock.Object);
         }
 
-        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSet<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object[]>? findByKeyExpression = null) where TEntity : class
+        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSet<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null) where TEntity : class
         {
-            dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
+            dbSetMock ??= new Mock<DbSet<TEntity>>();
+
+            ConfigureMock(dbSetMock, entities);
+
+            return setupResult.Returns(dbSetMock.Object);
+        }
+
+        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSet<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where TEntity : class
+        {
+            dbSetMock ??= new Mock<DbSet<TEntity>>();
 
             ConfigureMock(dbSetMock, entities, findByKeyExpression);
 
@@ -62,11 +89,9 @@
         /// <summary>
         /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queryable via LINQ
         /// </summary>
-        public static void ConfigureMock<TEntity>(Mock<DbSet<TEntity>> dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object[]>? findByKeyExpression = null) where TEntity : class
+        public static void ConfigureMock<TEntity>(Mock<DbSet<TEntity>> dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression) where TEntity : class
         {
             ConfigureMock((Mock)dbSetMock, entities);
-
-            if (findByKeyExpression is null) return;
 
             dbSetMock
                 .Setup(m => m.FindAsync(It.IsAny<object?[]?>()))

--- a/src/Moq.EntityFrameworkCore/MoqExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/MoqExtensions.cs
@@ -40,15 +40,15 @@
         }
 
         /// <summary>
-        /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queriable via LINQ
+        /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queryable via LINQ
         /// </summary>
-        public static void ConfigureMock<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object[]>? findByKeyExpression = null) where TEntity : class
+        public static void ConfigureMock<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities) where TEntity : class
         {
             var entitiesAsQueryable = entities.AsQueryable();
 
             dbSetMock.As<IAsyncEnumerable<TEntity>>()
-               .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
-               .Returns(() => new InMemoryDbAsyncEnumerator<TEntity>(entitiesAsQueryable.GetEnumerator()));
+                .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+                .Returns(() => new InMemoryDbAsyncEnumerator<TEntity>(entitiesAsQueryable.GetEnumerator()));
 
             dbSetMock.As<IQueryable<TEntity>>()
                 .Setup(m => m.Provider)
@@ -57,30 +57,32 @@
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.Expression).Returns(entitiesAsQueryable.Expression);
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.ElementType).Returns(entitiesAsQueryable.ElementType);
             dbSetMock.As<IQueryable<TEntity>>().Setup(m => m.GetEnumerator()).Returns(() => entitiesAsQueryable.GetEnumerator());
+        }
 
-            if (findByKeyExpression is not null)
-            {
-                if (dbSetMock is not Mock<DbSet<TEntity>> typedMock)
+        /// <summary>
+        /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queryable via LINQ
+        /// </summary>
+        public static void ConfigureMock<TEntity>(Mock<DbSet<TEntity>> dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object[]>? findByKeyExpression = null) where TEntity : class
+        {
+            ConfigureMock((Mock)dbSetMock, entities);
+
+            if (findByKeyExpression is null) return;
+
+            dbSetMock
+                .Setup(m => m.FindAsync(It.IsAny<object?[]?>()))
+                .Returns<object?[]?>(keyValues =>
                 {
-                    throw new ArgumentException($"dbSetMock must be a Mock<DbSet<{typeof(TEntity).Name}>> when findByKeyExpression is provided.", nameof(dbSetMock));
-                }
+                    if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
+                    return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
+                });
 
-                typedMock
-                    .Setup(m => m.FindAsync(It.IsAny<object?[]?>()))
-                    .Returns<object?[]?>(keyValues =>
-                    {
-                        if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
-                        return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
-                    });
-
-                typedMock
-                    .Setup(m => m.FindAsync(It.IsAny<object?[]?>(), It.IsAny<CancellationToken>()))
-                    .Returns<object?[]?, CancellationToken>((keyValues, _) =>
-                    {
-                        if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
-                        return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
-                    });
-            }
+            dbSetMock
+                .Setup(m => m.FindAsync(It.IsAny<object?[]?>(), It.IsAny<CancellationToken>()))
+                .Returns<object?[]?, CancellationToken>((keyValues, _) =>
+                {
+                    if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
+                    return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
+                });
         }
     }
 }

--- a/src/Moq.EntityFrameworkCore/MoqExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/MoqExtensions.cs
@@ -12,7 +12,7 @@
 
     public static class MoqExtensions
     {
-        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object>? findByKeyExpression = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object[]>? findByKeyExpression = null) where T : class where TEntity : class
         {
             dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
 
@@ -21,7 +21,7 @@
             return setupResult.Returns(dbSetMock.Object);
         }
 
-        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object>? findByKeyExpression = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object[]>? findByKeyExpression = null) where T : class where TEntity : class
         {
             dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
 
@@ -30,7 +30,7 @@
             return setupResult.Returns(dbSetMock.Object);
         }
 
-        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSet<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object>? findByKeyExpression = null) where TEntity : class
+        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSet<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Mock<DbSet<TEntity>>? dbSetMock = null, Func<TEntity, object[]>? findByKeyExpression = null) where TEntity : class
         {
             dbSetMock = dbSetMock ?? new Mock<DbSet<TEntity>>();
 
@@ -42,7 +42,7 @@
         /// <summary>
         /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queriable via LINQ
         /// </summary>
-        public static void ConfigureMock<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object>? findByKeyExpression = null) where TEntity : class
+        public static void ConfigureMock<TEntity>(Mock dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object[]>? findByKeyExpression = null) where TEntity : class
         {
             var entitiesAsQueryable = entities.AsQueryable();
 
@@ -60,14 +60,17 @@
 
             if (findByKeyExpression is not null)
             {
-                var typedMock = (Mock<DbSet<TEntity>>)dbSetMock;
+                if (dbSetMock is not Mock<DbSet<TEntity>> typedMock)
+                {
+                    throw new ArgumentException($"dbSetMock must be a Mock<DbSet<{typeof(TEntity).Name}>> when findByKeyExpression is provided.", nameof(dbSetMock));
+                }
 
                 typedMock
                     .Setup(m => m.FindAsync(It.IsAny<object?[]?>()))
                     .Returns<object?[]?>(keyValues =>
                     {
                         if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
-                        return ValueTask.FromResult(entities.FirstOrDefault(e => Equals(findByKeyExpression(e), keyValues[0])));
+                        return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
                     });
 
                 typedMock
@@ -75,7 +78,7 @@
                     .Returns<object?[]?, CancellationToken>((keyValues, _) =>
                     {
                         if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
-                        return ValueTask.FromResult(entities.FirstOrDefault(e => Equals(findByKeyExpression(e), keyValues[0])));
+                        return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
                     });
             }
         }

--- a/src/Moq.EntityFrameworkCore/MoqExtensions.cs
+++ b/src/Moq.EntityFrameworkCore/MoqExtensions.cs
@@ -21,7 +21,7 @@ namespace Moq.EntityFrameworkCore
             return setupResult.Returns(dbSetMock.Object);
         }
 
-        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetupGetter<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object?[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
         {
             dbSetMock ??= new Mock<DbSet<TEntity>>();
 
@@ -39,7 +39,7 @@ namespace Moq.EntityFrameworkCore
             return setupResult.Returns(dbSetMock.Object);
         }
 
-        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
+        public static IReturnsResult<T> ReturnsDbSet<T, TEntity>(this ISetup<T, DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object?[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where T : class where TEntity : class
         {
             dbSetMock ??= new Mock<DbSet<TEntity>>();
 
@@ -57,7 +57,7 @@ namespace Moq.EntityFrameworkCore
             return setupResult.Returns(dbSetMock.Object);
         }
 
-        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSet<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where TEntity : class
+        public static ISetupSequentialResult<DbSet<TEntity>> ReturnsDbSet<TEntity>(this ISetupSequentialResult<DbSet<TEntity>> setupResult, IEnumerable<TEntity> entities, Func<TEntity, object?[]> findByKeyExpression, Mock<DbSet<TEntity>>? dbSetMock = null) where TEntity : class
         {
             dbSetMock ??= new Mock<DbSet<TEntity>>();
 
@@ -88,17 +88,31 @@ namespace Moq.EntityFrameworkCore
 
         /// <summary>
         /// Configures a Mock for a <see cref="DbSet{TEntity}"/> so that it can be queryable via LINQ
+        /// and mocks <see cref="DbSet{TEntity}.FindAsync(object?[])"/> using the provided key expression.
         /// </summary>
-        public static void ConfigureMock<TEntity>(Mock<DbSet<TEntity>> dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object[]> findByKeyExpression) where TEntity : class
+        /// <param name="dbSetMock">The mock to configure.</param>
+        /// <param name="entities">The entities to use as the data source.</param>
+        /// <param name="findByKeyExpression">
+        /// A delegate that extracts the key values from an entity. The values must be returned in the same
+        /// order as they are passed to <see cref="DbSet{TEntity}.FindAsync(object?[])"/>, matching the
+        /// order of the key properties in the EF Core model.
+        /// </param>
+        public static void ConfigureMock<TEntity>(Mock<DbSet<TEntity>> dbSetMock, IEnumerable<TEntity> entities, Func<TEntity, object?[]> findByKeyExpression) where TEntity : class
         {
-            ConfigureMock((Mock)dbSetMock, entities);
+            ArgumentNullException.ThrowIfNull(findByKeyExpression);
+
+            // Materialise once so that both the LINQ queryable and FindAsync lambdas
+            // operate on the same snapshot and single-use enumerables are safe.
+            var entitiesList = entities.ToList();
+
+            ConfigureMock((Mock)dbSetMock, entitiesList);
 
             dbSetMock
                 .Setup(m => m.FindAsync(It.IsAny<object?[]?>()))
                 .Returns<object?[]?>(keyValues =>
                 {
                     if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
-                    return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
+                    return ValueTask.FromResult(entitiesList.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
                 });
 
             dbSetMock
@@ -106,7 +120,7 @@ namespace Moq.EntityFrameworkCore
                 .Returns<object?[]?, CancellationToken>((keyValues, _) =>
                 {
                     if (keyValues == null || keyValues.Length == 0) return ValueTask.FromResult<TEntity?>(default);
-                    return ValueTask.FromResult(entities.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
+                    return ValueTask.FromResult(entitiesList.FirstOrDefault(e => findByKeyExpression(e).SequenceEqual(keyValues!)));
                 });
         }
     }


### PR DESCRIPTION
## Add `FindAsync` support to `ReturnsDbSet`

### Motivation

`DbSet<TEntity>.FindAsync` is a commonly used method that was not previously covered by `ReturnsDbSet`, forcing consumers to manually set up the mock after calling it — or simply leaving `FindAsync` untested.

### Changes

Added an optional `findByKeyExpression` parameter to `ReturnsDbSet` that, when provided, configures a mock for both `FindAsync(object?[]?)` and `FindAsync(object?[]?, CancellationToken)` overloads.

```csharp
// Usage
dbContextMock
    .Setup(x => x.Set<User>())
    .ReturnsDbSet(users, findByKeyExpression: u => [u.Id]);
```

The parameter is optional and typed as `Func<TEntity, object[]>`, keeping the existing API fully backwards compatible.

### Why `Func<TEntity, object[]>` instead of automatic key resolution

Automatic key resolution via `IModel` or reflection was considered but ruled out for the following reasons:

- **`IModel`** requires an EF Core runtime, which is typically not available in unit tests with mocked `DbContext`.
- **Reflection-based fallback** adds implicit behaviour that can silently break when entity naming conventions are not followed.
- An explicit `Func<TEntity, object[]>` delegate is type-safe, refactor-friendly, and consistent with how the rest of the library works.

### Testing

Unit tests covering the following scenarios have been added:
- `FindAsync` returns the correct entity when a matching key is found.
- `FindAsync` returns `null` when no entity matches.
- `FindAsync` with `CancellationToken` behaves identically.
- Calling `ReturnsDbSet` without `findByKeyExpression` leaves `FindAsync` unconfigured (no regression).